### PR TITLE
Improved Soft sphere collision model 

### DIFF
--- a/src/CUDA/IBM/ibm.cu
+++ b/src/CUDA/IBM/ibm.cu
@@ -728,6 +728,7 @@ void gpuParticlesCollisionSoft(
             dfloat3 v_j = pc_j->vel;
             dfloat3 w_j = pc_j->w;
 
+            // there is chance it is divided by the particle diameter
             displacement = r_i + r_j - mag_dist;
 
             // relative velocity vector
@@ -751,10 +752,11 @@ void gpuParticlesCollisionSoft(
             
             
             //normal force
-            f_n =  (-STIFFNESS_NORMAL * sqrt(displacement*displacement*displacement) - DAMPING_NORMAL * G_mag);
-            f_normal.x = f_n * n.x;
-            f_normal.y = f_n * n.y;
-            f_normal.z = f_n * n.z;
+            dfloat f_kn = -STIFFNESS_NORMAL * sqrt(displacement*displacement*displacement);
+            f_normal.x = f_kn * n.x - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.x ;
+            f_normal.y = f_kn * n.y - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.y ;
+            f_normal.z = f_kn * n.z - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.z ;
+            f_n = sqrt(f_normal.x*f_normal.x + f_normal.y*f_normal.y + f_normal.z*f_normal.z);
 
             //tangential force       
             G_ct.x = G.x + r_i*(w_i.y*n.z - w_i.z*n.y) + r_j*(w_j.y*n.z - w_j.z*n.y) - (G.x*n.x + G.y*n.y + G.z*n.z) * n.x;

--- a/src/CUDA/IBM/ibm.cu
+++ b/src/CUDA/IBM/ibm.cu
@@ -684,11 +684,11 @@ void gpuParticlesCollisionSoft(
 
         // Particle i info (column)
         const dfloat3 pos_i = pc_i->pos;
-        const dfloat radius_i = pc_i->radius;
+        const dfloat r_i = pc_i->radius;
 
         // Particle j info (row)
         const dfloat3 pos_j = pc_j->pos;
-        const dfloat radius_j = pc_j->radius;
+        const dfloat r_j = pc_j->radius;
 
         // Particles position difference
         const dfloat3 diff_pos = dfloat3(
@@ -702,68 +702,143 @@ void gpuParticlesCollisionSoft(
             + diff_pos.y*diff_pos.y
             + diff_pos.z*diff_pos.z);
 
+        //normal collision vector
+        const dfloat3 n = dfloat3(diff_pos.x/mag_dist,diff_pos.y/mag_dist,diff_pos.z/mag_dist);
+        
         // Force on particle
-        dfloat f = 0;
         dfloat3 f_dirs = dfloat3();
+        dfloat3 m_dirs_i = dfloat3();
+        dfloat3 m_dirs_j = dfloat3();
 
-        // Buoyancy force
-        const dfloat b_force = grav * (pc_i->density - FLUID_DENSITY) * pc_i->volume;
 
         // Hard collision (one particle inside another)
-        if(mag_dist < radius_i+radius_j){
-            aux = (mag_dist - radius_i - radius_j - ZETA) / ZETA;
-            // Force to act on particles
-            f = ((b_force / STIFF_SOFT) * aux * aux 
-                + (b_force / STIFF_HARD) * 
-                ((radius_i + radius_j - mag_dist) / ZETA)) / mag_dist;
+        if(mag_dist < r_i+r_j){
+            dfloat3 f_normal = dfloat3();
+            dfloat3 f_tang = dfloat3();
+            dfloat3 t, G, G_ct,tang_disp;
+            dfloat G_mag,f_n,displacement,mag;
+
+            const dfloat  m_i = pc_i ->volume * pc_i ->density;
+            dfloat3 pos_old_i = pc_i->pos_old;
+            dfloat3 v_i = pc_i->vel;
+            dfloat3 w_i = pc_i->w;
+            
+            const dfloat  m_j = pc_j ->volume * pc_j ->density;
+            dfloat3 pos_old_j = pc_j->pos_old;
+            dfloat3 v_j = pc_j->vel;
+            dfloat3 w_j = pc_j->w;
+
+            displacement = r_i + r_j - mag_dist;
+
+            // relative velocity vector
+            G.x = v_i.x-v_j.x;
+            G.y = v_i.y-v_j.y;
+            G.z = v_i.z-v_j.z;
+            G_mag = sqrt(G.x * G.x + G.y * G.y + G.z * G.z);
+
+            //colision parameters
+
+            dfloat effective_radius = 1.0/((r_i +r_j)/(r_i*r_j));
+            dfloat effective_mass = 1.0/((m_i +m_j)/(m_i*m_j));
+
+            const dfloat STIFFNESS_NORMAL = STIFFNESS_NORMAL_CONST * sqrt(effective_radius);
+            const dfloat STIFFNESS_TANGENTIAL = STIFFNESS_TANGENTIAL_CONST * sqrt(effective_radius) * sqrt (displacement);
+            dfloat damping_const = (- 2.0 * log(REST_COEF)  / (sqrt(M_PI*M_PI + log(REST_COEF)))); //TODO FIND A WAY TO PROCESS IN COMPILE TIME
+            const dfloat DAMPING_NORMAL = damping_const
+                                        * sqrt (effective_mass * STIFFNESS_NORMAL );
+            const dfloat DAMPING_TANGENTIAL = damping_const 
+                                            * sqrt (effective_mass * STIFFNESS_TANGENTIAL);
+            
+            
+            //normal force
+            f_n =  (-STIFFNESS_NORMAL * sqrt(displacement*displacement*displacement) - DAMPING_NORMAL * G_mag);
+            f_normal.x = f_n * n.x;
+            f_normal.y = f_n * n.y;
+            f_normal.z = f_n * n.z;
+
+            //tangential force       
+            G_ct.x = G.x + r_i*(w_i.y*n.z - w_i.z*n.y) + r_j*(w_j.y*n.z - w_j.z*n.y) - (G.x*n.x + G.y*n.y + G.z*n.z) * n.x;
+            G_ct.y = G.y + r_i*(w_i.z*n.x - w_i.x*n.z) + r_j*(w_j.z*n.x - w_j.x*n.z) - (G.x*n.x + G.y*n.y + G.z*n.z) * n.y;
+            G_ct.z = G.z + r_i*(w_i.x*n.y - w_i.y*n.x) + r_j*(w_j.x*n.y - w_j.y*n.x) - (G.x*n.x + G.y*n.y + G.z*n.z) * n.z;
+        
+            mag = G_ct.x*G_ct.x+G_ct.y*G_ct.y+G_ct.z*G_ct.z;
+            mag=sqrt(mag);
+
+            if (mag != 0){
+                //tangential vector
+                t.x = G_ct.x/mag;
+                t.y = G_ct.y/mag;
+                t.z = G_ct.z/mag;
+            }else{
+                t.x = 0.0;
+                t.y = 0.0;
+                t.z = 0.0;
+            }
+            //tangential displacement = int_{t = t_0}^{t =t} G_ct dt, where t_0 is when occurred the contanct,
+            //here it will be made a inteporlation based on the old position of the particles
+            const dfloat3 diff_pos_old = dfloat3(
+                pos_old_i.x - pos_old_j.x,
+                pos_old_i.y - pos_old_j.y,
+                pos_old_i.z - pos_old_j.z); 
+            const dfloat mag_dist_old = sqrt(
+                  diff_pos_old.x*diff_pos_old.x
+                + diff_pos_old.y*diff_pos_old.y
+                + diff_pos_old.z*diff_pos_old.z);
+    
+            dfloat partial_collition_time = (mag_dist_old - (r_i+r_j))/(mag_dist_old - mag_dist);
+            partial_collition_time = 1.0;
+            tang_disp.x = partial_collition_time * G_ct.x;
+            tang_disp.y = partial_collition_time * G_ct.y;
+            tang_disp.z = partial_collition_time * G_ct.z;
+
+            f_tang.x = - STIFFNESS_TANGENTIAL * tang_disp.x - DAMPING_TANGENTIAL * G_ct.x;
+            f_tang.y = - STIFFNESS_TANGENTIAL * tang_disp.y - DAMPING_TANGENTIAL * G_ct.y;
+            f_tang.z = - STIFFNESS_TANGENTIAL * tang_disp.z - DAMPING_TANGENTIAL * G_ct.z;
+
+            mag = sqrt(f_tang.x*f_tang.x + f_tang.y*f_tang.y + f_tang.z*f_tang.z);
+
+            if(  mag > FRICTION_COEF * abs(f_n) ){
+                f_tang.x = - FRICTION_COEF * f_n * t.x;
+                f_tang.y = - FRICTION_COEF * f_n * t.y;
+                f_tang.z = - FRICTION_COEF * f_n * t.z;
+            }
+
 
             // Force in each direction
             f_dirs = dfloat3(
-                f * diff_pos.x,
-                f * diff_pos.y,
-                f * diff_pos.z
+                f_normal.x + f_tang.x,
+                f_normal.y + f_tang.y,
+                f_normal.z + f_tang.z
             );
-        }
-        // Soft collision (one particle close to another)
-        else if (mag_dist < radius_i+radius_j+ZETA){
-            aux = (mag_dist - radius_i - radius_j - ZETA) / ZETA;
-            // Force to act on particles
-            f = (b_force / STIFF_SOFT) * aux*aux / mag_dist;
+            //Torque in each direction
+            m_dirs_i = dfloat3(
+                r_i * (n.y*f_tang.z - n.z*f_tang.y),
+                r_i * (n.z*f_tang.x - n.x*f_tang.z),
+                r_i * (n.x*f_tang.y - n.y*f_tang.x)
+            );
+            m_dirs_j = dfloat3(
+                r_j * (n.y*f_tang.z - n.z*f_tang.y),
+                r_j * (n.z*f_tang.x - n.x*f_tang.z),
+                r_j * (n.x*f_tang.y - n.y*f_tang.x)
+            );
 
-            // Force in each direction
-            f_dirs = dfloat3(
-                f * diff_pos.x,
-                f * diff_pos.y,
-                f * diff_pos.z
-            );
-        }
-        // Add force on particles
-        if(f != 0){
-            // Both particles are movable
-            if(pc_i->movable && pc_j->movable){
-                // Force positive in particle i (column)
-                atomicAdd(&(pc_i->f.x), f_dirs.x);
-                atomicAdd(&(pc_i->f.y), f_dirs.y);
-                atomicAdd(&(pc_i->f.z), f_dirs.z);
-                // Force negative in particle j (row)
-                atomicAdd(&(pc_j->f.x), -f_dirs.x);
-                atomicAdd(&(pc_j->f.y), -f_dirs.y);
-                atomicAdd(&(pc_j->f.z), -f_dirs.z);
-            }
-            // Only particle i is movable
-            else if(pc_i->movable && !pc_j->movable){
-                // Force positive in particle i (column)
-                atomicAdd(&(pc_i->f.x), 2*f_dirs.x);
-                atomicAdd(&(pc_i->f.y), 2*f_dirs.y);
-                atomicAdd(&(pc_i->f.z), 2*f_dirs.z);
-            }
-            // Only particle j is movable
-            else{
-                // Force positive in particle i (column)
-                atomicAdd(&(pc_j->f.x), -2*f_dirs.x);
-                atomicAdd(&(pc_j->f.y), -2*f_dirs.y);
-                atomicAdd(&(pc_j->f.z), -2*f_dirs.z);
-            }
+            // Force positive in particle i (column)
+            atomicAdd(&(pc_i->f.x), -f_dirs.x);
+            atomicAdd(&(pc_i->f.y), -f_dirs.y);
+            atomicAdd(&(pc_i->f.z), -f_dirs.z);
+
+            atomicAdd(&(pc_i->M.x), m_dirs_i.x);
+            atomicAdd(&(pc_i->M.y), m_dirs_i.y);
+            atomicAdd(&(pc_i->M.z), m_dirs_i.z);
+
+            // Force negative in particle j (row)
+            atomicAdd(&(pc_j->f.x), f_dirs.x);
+            atomicAdd(&(pc_j->f.y), f_dirs.y);
+            atomicAdd(&(pc_j->f.z), f_dirs.z);
+
+            atomicAdd(&(pc_j->M.x), m_dirs_j.x); //normal vector takes care of negative sign
+            atomicAdd(&(pc_j->M.y), m_dirs_j.y);
+            atomicAdd(&(pc_j->M.z), m_dirs_j.z);           
         }
     }
 }
@@ -823,7 +898,7 @@ void gpuParticlesCollisionHard(
         dfloat dist_abs = abs(pos_i.x - pos_mirror);     
         if (dist_abs <= min_dist){
             px = -(min_dist - dist_abs)/2;
-            if ( (v_i.x / vel_mag) < -2 / (7*FRIC_COEF*(REST_COEF+1)) && FRIC_COEF != 0){
+            if ( (v_i.x / vel_mag) < -2 / (7*FRICTION_COEF*(REST_COEF+1)) && FRICTION_COEF != 0){
                 dvy_i -= v_i.y - (5.0/7.0)*(v_i.y - 2*r_i*w_i.z/5);
                 dvz_i -= v_i.z - (5.0/7.0)*(v_i.z - 2*r_i*w_i.y/5);
 
@@ -848,13 +923,13 @@ void gpuParticlesCollisionHard(
                     ep_y = v_i.y/ep_mag;
                     ep_z = v_i.z/ep_mag;
                 }
-                dvy_i += ep_y*FRIC_COEF*(REST_COEF+1)*v_i.x;
-                dvz_i += ep_z*FRIC_COEF*(REST_COEF+1)*v_i.x;
+                dvy_i += ep_y*FRICTION_COEF*(REST_COEF+1)*v_i.x;
+                dvz_i += ep_z*FRICTION_COEF*(REST_COEF+1)*v_i.x;
 
                 dvx_i -= v_i.x + REST_COEF * v_i.x;
 
-                dwy_i += - (5.0/(2.0*r_i))*ep_z*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.x);
-                dwz_i += + (5.0/(2.0*r_i))*ep_y*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.x);
+                dwy_i += - (5.0/(2.0*r_i))*ep_z*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.x);
+                dwz_i += + (5.0/(2.0*r_i))*ep_y*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.x);
                 dwx_i += 0;
             }
 
@@ -864,7 +939,7 @@ void gpuParticlesCollisionHard(
         dist_abs = abs(pos_i.x - pos_mirror);
         if (dist_abs <= min_dist){
             px = (min_dist - dist_abs)/2;
-            if ( (v_i.x / vel_mag) < 2 / (7*FRIC_COEF*(REST_COEF+1)) && FRIC_COEF != 0){
+            if ( (v_i.x / vel_mag) < 2 / (7*FRICTION_COEF*(REST_COEF+1)) && FRICTION_COEF != 0){
                 dvy_i -= v_i.y - (5.0/7.0)*(v_i.y - 2*r_i*w_i.z/5);
                 dvz_i -= v_i.z - (5.0/7.0)*(v_i.z - 2*r_i*w_i.y/5);
 
@@ -890,13 +965,13 @@ void gpuParticlesCollisionHard(
                     ep_z = v_i.z/ep_mag;
                 }
 
-                dvy_i += ep_y*FRIC_COEF*(REST_COEF+1)*v_i.x;
-                dvz_i += ep_z*FRIC_COEF*(REST_COEF+1)*v_i.x;
+                dvy_i += ep_y*FRICTION_COEF*(REST_COEF+1)*v_i.x;
+                dvz_i += ep_z*FRICTION_COEF*(REST_COEF+1)*v_i.x;
 
                 dvx_i -= v_i.x + REST_COEF * v_i.x;
 
-                dwy_i += - (5.0/(2.0*r_i))*ep_z*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.x);
-                dwz_i += + (5.0/(2.0*r_i))*ep_y*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.x);
+                dwy_i += - (5.0/(2.0*r_i))*ep_z*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.x);
+                dwz_i += + (5.0/(2.0*r_i))*ep_y*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.x);
                 dwx_i += 0;
             }
         }
@@ -906,7 +981,7 @@ void gpuParticlesCollisionHard(
         dist_abs = abs(pos_i.y - pos_mirror);
         if (dist_abs <= min_dist){
             py = -(min_dist - dist_abs)/2;
-            if ( (v_i.y / vel_mag) < -2 / (7*FRIC_COEF*(REST_COEF+1))  && FRIC_COEF != 0){
+            if ( (v_i.y / vel_mag) < -2 / (7*FRICTION_COEF*(REST_COEF+1))  && FRICTION_COEF != 0){
                 dvx_i -= v_i.x - (5.0/7.0)*(v_i.x - 2*r_i*w_i.z/5);
                 dvz_i -= v_i.z - (5.0/7.0)*(v_i.z - 2*r_i*w_i.x/5);
 
@@ -933,13 +1008,13 @@ void gpuParticlesCollisionHard(
                     ep_z = v_i.z/ep_mag;
                 }
 
-                dvx_i += ep_x*FRIC_COEF*(REST_COEF+1)*v_i.y;
-                dvz_i += ep_z*FRIC_COEF*(REST_COEF+1)*v_i.y;
+                dvx_i += ep_x*FRICTION_COEF*(REST_COEF+1)*v_i.y;
+                dvz_i += ep_z*FRICTION_COEF*(REST_COEF+1)*v_i.y;
 
                 dvy_i -= v_i.y + REST_COEF * v_i.y;
 
-                dwx_i += - (5.0/(2.0*r_i))*ep_z*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.y);
-                dwz_i += + (5.0/(2.0*r_i))*ep_x*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.y);
+                dwx_i += - (5.0/(2.0*r_i))*ep_z*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.y);
+                dwz_i += + (5.0/(2.0*r_i))*ep_x*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.y);
                 dwy_i += 0;
             }
         }
@@ -949,7 +1024,7 @@ void gpuParticlesCollisionHard(
         dist_abs = abs(pos_i.y - pos_mirror);
         if (dist_abs <= min_dist){
             py = (min_dist - dist_abs)/2;
-            if ( (v_i.y / vel_mag) < 2 / (7*FRIC_COEF*(REST_COEF+1)) && FRIC_COEF != 0){
+            if ( (v_i.y / vel_mag) < 2 / (7*FRICTION_COEF*(REST_COEF+1)) && FRICTION_COEF != 0){
                 dvx_i -= v_i.x - (5.0/7.0)*(v_i.x - 2*r_i*w_i.z/5);
                 dvz_i -= v_i.z - (5.0/7.0)*(v_i.z - 2*r_i*w_i.x/5);
 
@@ -973,13 +1048,13 @@ void gpuParticlesCollisionHard(
                     ep_x = v_i.x/ep_mag;
                     ep_z = v_i.z/ep_mag;
                 }
-                dvx_i += + ep_x*FRIC_COEF*(REST_COEF+1)*v_i.y;
-                dvz_i += + ep_z*FRIC_COEF*(REST_COEF+1)*v_i.y;
+                dvx_i += + ep_x*FRICTION_COEF*(REST_COEF+1)*v_i.y;
+                dvz_i += + ep_z*FRICTION_COEF*(REST_COEF+1)*v_i.y;
 
                 dvy_i -= v_i.y + REST_COEF * v_i.y;
 
-                dwx_i += - (5.0/(2.0*r_i))*ep_z*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.y);
-                dwz_i += + (5.0/(2.0*r_i))*ep_x*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.y);
+                dwx_i += - (5.0/(2.0*r_i))*ep_z*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.y);
+                dwz_i += + (5.0/(2.0*r_i))*ep_x*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.y);
                 dwy_i += 0;
             }
         }
@@ -988,7 +1063,7 @@ void gpuParticlesCollisionHard(
         dist_abs = abs(pos_i.z - pos_mirror);
         if (dist_abs <= min_dist){
             pz = -(min_dist - dist_abs)/2;
-            if ( (v_i.z / vel_mag) < -2 / (7*FRIC_COEF*(REST_COEF+1)) && FRIC_COEF != 0){
+            if ( (v_i.z / vel_mag) < -2 / (7*FRICTION_COEF*(REST_COEF+1)) && FRICTION_COEF != 0){
                 dvx_i -= v_i.x - (5.0/7.0)*(v_i.x - 2*r_i*w_i.y/5);
                 dvy_i -= v_i.y - (5.0/7.0)*(v_i.y - 2*r_i*w_i.x/5);
 
@@ -1012,14 +1087,14 @@ void gpuParticlesCollisionHard(
                     ep_x = v_i.x/ep_mag;
                     ep_y = v_i.y/ep_mag;
                 }    
-                dvx_i += ep_x*FRIC_COEF*(REST_COEF+1)*v_i.z;
-                dvy_i += ep_y*FRIC_COEF*(REST_COEF+1)*v_i.z;
+                dvx_i += ep_x*FRICTION_COEF*(REST_COEF+1)*v_i.z;
+                dvy_i += ep_y*FRICTION_COEF*(REST_COEF+1)*v_i.z;
 
                 dvz_i -= v_i.z + REST_COEF * v_i.z;
 
                 
-                dwx_i += - (5.0/(2.0*r_i))*ep_y*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.z);
-                dwy_i += + (5.0/(2.0*r_i))*ep_x*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.z);
+                dwx_i += - (5.0/(2.0*r_i))*ep_y*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.z);
+                dwy_i += + (5.0/(2.0*r_i))*ep_x*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.z);
                 dwz_i += 0;
             }
 
@@ -1030,7 +1105,7 @@ void gpuParticlesCollisionHard(
         dist_abs = abs(pos_i.z - pos_mirror);
         if (dist_abs <= min_dist) {
             pz = (min_dist - dist_abs)/2;
-            if ( (v_i.z / vel_mag) < 2 / (7*FRIC_COEF*(REST_COEF+1)) && FRIC_COEF != 0){
+            if ( (v_i.z / vel_mag) < 2 / (7*FRICTION_COEF*(REST_COEF+1)) && FRICTION_COEF != 0){
                 dvx_i -= v_i.x - (5.0/7.0)*(v_i.x - 2*r_i*w_i.y/5);
                 dvy_i -= v_i.y - (5.0/7.0)*(v_i.y - 2*r_i*w_i.x/5);
 
@@ -1055,13 +1130,13 @@ void gpuParticlesCollisionHard(
                     ep_y = v_i.y/ep_mag;
                 }
 
-                dvx_i += ep_x*FRIC_COEF*(REST_COEF+1)*v_i.z;
-                dvy_i += ep_y*FRIC_COEF*(REST_COEF+1)*v_i.z;
+                dvx_i += ep_x*FRICTION_COEF*(REST_COEF+1)*v_i.z;
+                dvy_i += ep_y*FRICTION_COEF*(REST_COEF+1)*v_i.z;
 
                 dvz_i -= v_i.z + REST_COEF * v_i.z;
 
-                dwx_i += - (5.0/(2.0*r_i))*ep_y*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.z);
-                dwy_i += + (5.0/(2.0*r_i))*ep_x*FRIC_COEF*(REST_COEF+1)*(-REST_COEF * v_i.z);
+                dwx_i += - (5.0/(2.0*r_i))*ep_y*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.z);
+                dwy_i += + (5.0/(2.0*r_i))*ep_x*FRICTION_COEF*(REST_COEF+1)*(-REST_COEF * v_i.z);
                 dwz_i += 0;
             }
         }
@@ -1172,31 +1247,31 @@ void gpuParticlesCollisionHard(
                 t.y = G_ct_0.y/mag;
                 t.z = G_ct_0.z/mag;
             }else{
-                t.x = 1.0;
-                t.y = 1.0;
-                t.z = 1.0;
+                t.x = 0.0;
+                t.y = 0.0;
+                t.z = 0.0;
             }
             dfloat nG_0;
 
             nG_0 = (n.x*G_0.x+n.y*G_0.y+n.z*G_0.z);
 
             // translational velocity change
-            const dfloat dvx_i = - (n.x+FRIC_COEF*t.x)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j));  
-            const dfloat dvy_i = - (n.y+FRIC_COEF*t.y)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j));
-            const dfloat dvz_i = - (n.z+FRIC_COEF*t.z)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j));
+            const dfloat dvx_i = - (n.x+FRICTION_COEF*t.x)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j));  
+            const dfloat dvy_i = - (n.y+FRICTION_COEF*t.y)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j));
+            const dfloat dvz_i = - (n.z+FRICTION_COEF*t.z)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j));
 
-            const dfloat dvx_j = + (n.x+FRIC_COEF*t.x)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j));
-            const dfloat dvy_j = + (n.y+FRIC_COEF*t.y)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j));
-            const dfloat dvz_j = + (n.z+FRIC_COEF*t.z)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j));
+            const dfloat dvx_j = + (n.x+FRICTION_COEF*t.x)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j));
+            const dfloat dvy_j = + (n.y+FRICTION_COEF*t.y)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j));
+            const dfloat dvz_j = + (n.z+FRICTION_COEF*t.z)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j));
 
             //rotational velocity change
-            const dfloat dwx_i = - (2.5/r_i)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j))*FRIC_COEF*(n.y*t.z-n.z*t.y);
-            const dfloat dwy_i = - (2.5/r_i)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j))*FRIC_COEF*(n.z*t.x-n.x*t.z);
-            const dfloat dwz_i = - (2.5/r_i)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j))*FRIC_COEF*(n.x*t.y-n.y*t.x);
+            const dfloat dwx_i = - (2.5/r_i)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j))*FRICTION_COEF*(n.y*t.z-n.z*t.y);
+            const dfloat dwy_i = - (2.5/r_i)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j))*FRICTION_COEF*(n.z*t.x-n.x*t.z);
+            const dfloat dwz_i = - (2.5/r_i)*nG_0*(1+REST_COEF)*(m_j/(m_i+m_j))*FRICTION_COEF*(n.x*t.y-n.y*t.x);
         
-            const dfloat dwx_j = - (2.5/r_j)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j))*FRIC_COEF*(n.y*t.z-n.z*t.y);
-            const dfloat dwy_j = - (2.5/r_j)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j))*FRIC_COEF*(n.z*t.x-n.x*t.z);
-            const dfloat dwz_j = - (2.5/r_j)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j))*FRIC_COEF*(n.x*t.y-n.y*t.x);
+            const dfloat dwx_j = - (2.5/r_j)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j))*FRICTION_COEF*(n.y*t.z-n.z*t.y);
+            const dfloat dwy_j = - (2.5/r_j)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j))*FRICTION_COEF*(n.z*t.x-n.x*t.z);
+            const dfloat dwz_j = - (2.5/r_j)*nG_0*(1+REST_COEF)*(m_i/(m_i+m_j))*FRICTION_COEF*(n.x*t.y-n.y*t.x);
 
             // particle velocity update
             dfloat add_dist = 1e-3;

--- a/src/CUDA/IBM/ibmVar.h
+++ b/src/CUDA/IBM/ibmVar.h
@@ -12,15 +12,16 @@
 
 #include "../var.h"
 #include <stdio.h>
+#include <math.h>
 
 
 /* -------------------------- IBM GENERAL DEFINES --------------------------- */
 // Total number of IB particles in the system
-#define NUM_PARTICLES 1
+#define NUM_PARTICLES 2
 // Number of IBM inner iterations
 #define IBM_MAX_ITERATION 3
 // Particles diameters
-#define PARTICLE_DIAMETER (15*SCALE)
+#define PARTICLE_DIAMETER (20*SCALE)
 // Mesh scale for IBM, minimum distance between nodes (lower, more nodes in particle)
 #define MESH_SCALE 1.0
 // Number of iterations of Coulomb algorithm to optimize the nodes positions
@@ -40,7 +41,7 @@
 /* ---------------------------- IBM OPTIMIZATION --------------------------- */
 // Optimize Euler nodes updates for IBM (only recommended to test false
 // with a ratio of more than 5% between lagrangian and eulerian nodes)
-#define IBM_EULER_OPTIMIZATION true
+#define IBM_EULER_OPTIMIZATION false
 // "Shell thickness" to consider. The Euler nodes are updated every time 
 // the particle moves more than IBM_EULER_UPDATE_DIST value and all nodes with 
 // less than IBM_EULER_SHELL_THICKNESS+P_DIST distant from the particle are updated.
@@ -67,8 +68,8 @@
 /* ------------------------------------------------------------------------- */
 
 /* ------------------------- TIME AND SAVE DEFINES ------------------------- */
-#define IBM_PARTICLES_SAVE (100*SCALE*SCALE)               // Save particles info every given steps (0 not report)
-#define IBM_DATA_REPORT (100*SCALE*SCALE)                   // Report IBM treated data every given steps (0 not report)
+#define IBM_PARTICLES_SAVE (10*SCALE*SCALE)               // Save particles info every given steps (0 not report)
+#define IBM_DATA_REPORT (10*SCALE*SCALE)                   // Report IBM treated data every given steps (0 not report)
  
 #define IBM_DATA_STOP true                 // stop condition by IBM treated data
 #define IBM_DATA_SAVE true                 // save reported IBM data to file
@@ -83,12 +84,30 @@ constexpr dfloat FLUID_DENSITY = 1;
 // Gravity accelaration on particle (Lattice units)
 constexpr dfloat GX = 0.0;
 constexpr dfloat GY = 0.0;
-constexpr dfloat GZ = -1.179430e-03/SCALE/SCALE/SCALE;
+constexpr dfloat GZ = 0.0; //-1.179430e-03/SCALE/SCALE/SCALE;
 /* -------------------------------------------------------------------------- */
 
 /* -------------------------- COLLISION PARAMETERS -------------------------- */
 // Soft sphere
 #if defined SOFT_SPHERE
+constexpr dfloat FRICTION_COEF = 0.001; // friction coeficient
+constexpr dfloat REST_COEF = 1.0; // restitution coeficient   
+
+//material properties
+constexpr dfloat YOUNG_MODULUS = 1.0;
+constexpr dfloat POISSON_RATIO = 0.33;
+constexpr dfloat SHEAR_MODULUS = YOUNG_MODULUS / (2.0+2.0*POISSON_RATIO);
+
+
+//Hertzian contact theory -  Johnson 1985
+constexpr dfloat STIFFNESS_NORMAL_CONST = (2.0/3.0) * (YOUNG_MODULUS / (1-POISSON_RATIO*POISSON_RATIO)); 
+//Mindlin theory 1949
+constexpr dfloat STIFFNESS_TANGENTIAL_CONST =  4.0 * (SHEAR_MODULUS / (1 - POISSON_RATIO*POISSON_RATIO)); 
+// Tsuji 1979
+//constexpr dfloat DAMPING_NORMAL_CONST =       - 2.0 * log(REST_COEF)  / (sqrt(M_PI*M_PI + log(REST_COEF)));
+//constexpr dfloat DAMPING_TANGENTIAL_CONST =   - 2.0 * log(REST_COEF)  / (sqrt(M_PI*M_PI + log(REST_COEF))); 
+
+
 constexpr dfloat ZETA = 1.0; // Distance threshold
 constexpr dfloat STIFF_WALL = 1.0;  // Stiffness parameter wall
 constexpr dfloat STIFF_SOFT = 1.0;  // Soft stiffness parameter particle

--- a/src/CUDA/lbmReport.cpp
+++ b/src/CUDA/lbmReport.cpp
@@ -294,15 +294,20 @@ std::string getSimInfoString(SimInfo* info)
     #endif
     #if defined SOFT_SPHERE
     strSimInfo << "--------------------------------- IBM Collision --------------------------------\n";
-    strSimInfo << "\t                 Zeta: " << ZETA << "\n";
+    strSimInfo << "\t       Friction Coef.: " << FRICTION_COEF << "\n";
+    strSimInfo << "\t   Restitution  Coef.: " << REST_COEF << "\n";
+    strSimInfo << "\t      Young's Modulus: " << YOUNG_MODULUS << "\n";
+    strSimInfo << "\t        Poisson Ratio: " << POISSON_RATIO << "\n";
+    strSimInfo << "\t       Shear Modulus.: " << SHEAR_MODULUS << "\n";
+    /*strSimInfo << "\t                 Zeta: " << ZETA << "\n";
     strSimInfo << "\t           Stiff wall: " << STIFF_WALL << "\n";
     strSimInfo << "\t           Stiff soft: " << STIFF_SOFT << "\n";
-    strSimInfo << "\t           Stiff hard: " << STIFF_HARD << "\n";
+    strSimInfo << "\t           Stiff hard: " << STIFF_HARD << "\n";*/
     strSimInfo << "--------------------------------------------------------------------------------\n";
     #endif //SOFT_SPHERE
     #if defined HARD_SPHERE
     strSimInfo << "--------------------------------- IBM Collision --------------------------------\n";
-    strSimInfo << "\t       Friction Coef.: " << FRIC_COEF << "\n";
+    strSimInfo << "\t       Friction Coef.: " << FRICTION_COEF << "\n";
     strSimInfo << "\t   Restitution  Coef.: " << REST_COEF << "\n";
     strSimInfo << "--------------------------------------------------------------------------------\n";
     #endif //HARD_SPHERE


### PR DESCRIPTION
Soft sphere collision model changed
Proteus method from feng & michaelides (2005) removed;
Now it is based on (Johnson, 1985) for spring forces and (Tsuji et al., 1993) for damping forces according to Hertzian contact theory.

Apparently, the restitution coefficient depends on the particle velocity ( higher velocity increases the restitution coefficient).
This could be a consequence of the initial penetration state vs release penetration.

Currently, the tangential force is undervalued since it needs to be considered a sum of G from the contact point, which currently there is no way to track it. Recommended, for now, use FRICTION_COEF = 0.0