### PR TITLE
Changes to Particle Collision

### DIFF
--- a/src/CUDA/IBM/collision/ibmCollision.cu
+++ b/src/CUDA/IBM/collision/ibmCollision.cu
@@ -6,7 +6,8 @@
 __global__
 void gpuParticlesCollision(
     ParticleNodeSoA particlesNodes,
-    ParticleCenter particleCenters[NUM_PARTICLES]
+    ParticleCenter particleCenters[NUM_PARTICLES],
+    unsigned int step
 ){
 
     /* Maps a 1D array to a Floyd triangle, where the last row is for checking
@@ -91,7 +92,7 @@ void gpuParticlesCollision(
                     displacement = (2.0 * r_i - dist_abs)/2.0;
 
                     #ifdef SOFT_SPHERE
-                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                     #endif
                     #ifdef HARD_SPHERE
                     penetration = dfloat3(-(min_dist - dist_abs)/2.0,0.0,0.0);
@@ -111,7 +112,7 @@ void gpuParticlesCollision(
                 normalVector.z = 0.0;
 
                 #ifdef SOFT_SPHERE
-                gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                 #endif
                 #ifdef HARD_SPHERE
                 penetration = dfloat3(-(min_dist - dist_abs)/2.0,0.0,0.0);
@@ -134,7 +135,7 @@ void gpuParticlesCollision(
                     displacement = (2.0 * r_i - dist_abs)/2.0;;
                                        
                     #ifdef SOFT_SPHERE
-                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                     #endif
                     #ifdef HARD_SPHERE
                     penetration = dfloat3((min_dist - dist_abs)/2,0.0,0.0);
@@ -154,7 +155,7 @@ void gpuParticlesCollision(
                 normalVector.z = 0.0;
                 
                 #ifdef SOFT_SPHERE
-                gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                 #endif
                 #ifdef HARD_SPHERE
                 penetration = dfloat3((min_dist - dist_abs)/2,0.0,0.0);
@@ -177,7 +178,7 @@ void gpuParticlesCollision(
                     displacement = (2.0 * r_i - dist_abs)/2.0;
             
                     #ifdef SOFT_SPHERE
-                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                     #endif
                     #ifdef HARD_SPHERE
                     penetration = dfloat3(0.0,-(min_dist - dist_abs)/2.0,0.0);
@@ -197,7 +198,7 @@ void gpuParticlesCollision(
                 normalVector.z = 0.0;
 
                 #ifdef SOFT_SPHERE
-                gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                 #endif
                 #ifdef HARD_SPHERE
                 penetration = dfloat3(0.0,-(min_dist - dist_abs)/2.0,0.0);
@@ -220,7 +221,7 @@ void gpuParticlesCollision(
                     displacement = (2.0 * r_i - dist_abs)/2.0;
 
                     #ifdef SOFT_SPHERE
-                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                     #endif
                     #ifdef HARD_SPHERE
                     penetration = dfloat3(0.0,(min_dist - dist_abs)/2.0,0.0);
@@ -240,7 +241,7 @@ void gpuParticlesCollision(
                 normalVector.z = 0.0;
 
                 #ifdef SOFT_SPHERE
-                gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                 #endif
                 #ifdef HARD_SPHERE
                 penetration = dfloat3(0.0,(min_dist - dist_abs)/2.0,0.0);
@@ -263,7 +264,7 @@ void gpuParticlesCollision(
                     displacement = (2.0 * r_i - dist_abs)/2.0;
                     
                     #ifdef SOFT_SPHERE
-                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                     #endif
                     #ifdef HARD_SPHERE
                     penetration = dfloat3(0.0,0.0,-(min_dist - dist_abs)/2.0);
@@ -283,7 +284,7 @@ void gpuParticlesCollision(
                 normalVector.z = 1.0;
 
                 #ifdef SOFT_SPHERE
-                gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                 #endif
                 #ifdef HARD_SPHERE
                 penetration = dfloat3(0.0,0.0,-(min_dist - dist_abs)/2.0);
@@ -308,7 +309,7 @@ void gpuParticlesCollision(
                     displacement = (2.0 * r_i - dist_abs)/2.0;
     
                     #ifdef SOFT_SPHERE
-                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                    gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                     #endif //SOFT_SPHERE
                     #ifdef HARD_SPHERE
                     penetration = dfloat3(0.0,0.0,(min_dist - dist_abs)/2.0);
@@ -328,7 +329,7 @@ void gpuParticlesCollision(
                 normalVector.z = -1.0;
 
                 #ifdef SOFT_SPHERE
-                gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                 #endif
                 #ifdef HARD_SPHERE
                 penetration = dfloat3(0.0,0.0,(min_dist - dist_abs)/2.0);
@@ -363,7 +364,7 @@ void gpuParticlesCollision(
                     if (dist_abs <= min_dist) {
                         displacement = (2.0 * r_i - dist_abs)/2.0;
                         #ifdef SOFT_SPHERE
-                            gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                            gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                         #endif //SOFT_SPHERE
                         #ifdef HARD_SPHERE
                         #endif  //HARD_SPHERE
@@ -379,7 +380,7 @@ void gpuParticlesCollision(
                     normalVector.y = (pos_i.y-yCenter)/pos_r_i;
                     normalVector.z = 0.0;
                     #ifdef SOFT_SPHERE
-                        gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                        gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                     #endif //SOFT_SPHERE
                     #ifdef HARD_SPHERE
                     #endif  //HARD_SPHERE
@@ -403,7 +404,7 @@ void gpuParticlesCollision(
                     if (dist_abs <= min_dist) {
                         displacement = (2.0 * r_i - dist_abs)/2.0;
                         #ifdef SOFT_SPHERE
-                            gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                            gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                         #endif //SOFT_SPHERE
                         #ifdef HARD_SPHERE
                         #endif  //HARD_SPHERE
@@ -419,7 +420,7 @@ void gpuParticlesCollision(
                     normalVector.y = 0.0;
                     normalVector.z = 0.0;
                     #ifdef SOFT_SPHERE
-                        gpuSoftSphereWallCollision(displacement,normalVector,pc_i);
+                        gpuSoftSphereWallCollision(displacement,normalVector,pc_i,step);
                     #endif //SOFT_SPHERE
                     #ifdef HARD_SPHERE
                     #endif  //HARD_SPHERE
@@ -491,7 +492,8 @@ __device__
 void gpuSoftSphereWallCollision(
     dfloat displacement,
     dfloat3 n,
-    ParticleCenter* pc_i
+    ParticleCenter* pc_i,
+    unsigned int step
 ){
 
 

--- a/src/CUDA/IBM/collision/ibmCollision.cu
+++ b/src/CUDA/IBM/collision/ibmCollision.cu
@@ -532,7 +532,7 @@ void gpuSoftSphereWallCollision(
     const dfloat STIFFNESS_TANGENTIAL = STIFFNESS_TANGENTIAL_CONST * sqrt(effective_radius) * sqrt (displacement);
     const dfloat damping_const = (- 2.0 * log(REST_COEF)  / (sqrt(M_PI*M_PI + log(REST_COEF)))); //TODO FIND A WAY TO PROCESS IN COMPILE TIME
     const dfloat DAMPING_NORMAL = damping_const * sqrt (effective_mass * STIFFNESS_NORMAL );
-    const dfloat DAMPING_TANGENTIAL = 2.0* damping_const * sqrt (effective_mass * STIFFNESS_TANGENTIAL);
+    const dfloat DAMPING_TANGENTIAL = damping_const * sqrt (effective_mass * STIFFNESS_TANGENTIAL);
 
 
     //normal force
@@ -561,6 +561,8 @@ void gpuSoftSphereWallCollision(
         t.z = 0.0;
     }
 
+    //printf("\n -- G_ct.x : %f -- G_ct.y : %f -- G_ct.z : %f", G_ct.x, G_ct.y, G_ct.z);
+
     //TODO : Still need validation
     tang_disp.x = G_ct.x + tangDisplacement.x;
     tang_disp.y = G_ct.y + tangDisplacement.y;
@@ -572,9 +574,12 @@ void gpuSoftSphereWallCollision(
     f_tang.y = - STIFFNESS_TANGENTIAL * tang_disp.y - DAMPING_TANGENTIAL * G_ct.y;
     f_tang.z = - STIFFNESS_TANGENTIAL * tang_disp.z - DAMPING_TANGENTIAL * G_ct.z;
 
+    //printf("\n -- f_ct.x : %f -- f_ct.y : %f -- f_ct.z : %f", f_tang.x, f_tang.y, f_tang.z);
+
     mag = sqrt(f_tang.x*f_tang.x + f_tang.y*f_tang.y + f_tang.z*f_tang.z);
 
     if(  mag > FRICTION_COEF * abs(f_n) ){
+        //printf("\n entered if, mag: %f > %f", mag,FRICTION_COEF * abs(f_n));
         f_tang.x = - FRICTION_COEF * f_n * t.x;
         f_tang.y = - FRICTION_COEF * f_n * t.y;
         f_tang.z = - FRICTION_COEF * f_n * t.z;
@@ -680,9 +685,9 @@ void gpuSoftSphereParticleCollision(
     
     //normal force
     dfloat f_kn = -STIFFNESS_NORMAL * sqrt(displacement*displacement*displacement);
-    f_normal.x = f_kn * n.x - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.x ;
-    f_normal.y = f_kn * n.y - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.y ;
-    f_normal.z = f_kn * n.z - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.z ;
+    f_normal.x = f_kn * n.x - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.x * POW_FUNCTION(displacement,0.25); ;
+    f_normal.y = f_kn * n.y - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.y * POW_FUNCTION(displacement,0.25); ;
+    f_normal.z = f_kn * n.z - DAMPING_NORMAL * (G.x*n.x + G.y*n.y + G.z*n.z)*n.z * POW_FUNCTION(displacement,0.25);;
     f_n = sqrt(f_normal.x*f_normal.x + f_normal.y*f_normal.y + f_normal.z*f_normal.z);
 
     //tangential force       

--- a/src/CUDA/IBM/collision/ibmCollision.cu
+++ b/src/CUDA/IBM/collision/ibmCollision.cu
@@ -906,7 +906,7 @@ int gpuTangentialDisplacementTrackerParticle(
         }
     }
     endloop_i:
-
+    /* Its not necessary, removing also prevents race condition
     //TODO: Evaluate if is really necessary track information in both particles.
     //check tracking for particle j
     for(int i = 0; i < trackerCollisionSize; i++){
@@ -950,14 +950,14 @@ int gpuTangentialDisplacementTrackerParticle(
             }
         }
     }
-    endloop_j:
+    endloop_j:*/
 
 
     // update tracker info
     //TODO THIS NEEDS TO BE ATOMIC
     for(int i = 0; i < trackerCollisionSize; i++){
         pc_i->tCT[i] = trackInfo_i[i];
-        pc_j->tCT[i] = trackInfo_j[i];
+        //pc_j->tCT[i] = trackInfo_j[i];
     }
 
     return trackerId;

--- a/src/CUDA/IBM/collision/ibmCollision.h
+++ b/src/CUDA/IBM/collision/ibmCollision.h
@@ -23,11 +23,13 @@
 *   
 *   @param particlesNodes: particles nodes to update
 *   @param particleCenters: particles centers to perform colision
+*   @param step: current time step
 */
 __global__ 
 void gpuParticlesCollision(
     ParticleNodeSoA particlesNodes,
-    ParticleCenter particleCenters[NUM_PARTICLES]
+    ParticleCenter particleCenters[NUM_PARTICLES],
+    unsigned int step
 );
 
 /**
@@ -36,12 +38,14 @@ void gpuParticlesCollision(
 *   @param displacement: total normal displacement
 *   @param wallNormalVector: wall normal vector  
 *   @param particleCenter: particles centers to perform colision index i
+*   @param step: current time step
 */
 __device__ 
 void gpuSoftSphereWallCollision(
     dfloat displacement,
     dfloat3 wallNormalVector,
-    ParticleCenter* pc_i
+    ParticleCenter* pc_i,
+    unsigned int step
 );
 
 /**

--- a/src/CUDA/IBM/collision/ibmCollision.h
+++ b/src/CUDA/IBM/collision/ibmCollision.h
@@ -52,29 +52,56 @@ void gpuSoftSphereWallCollision(
 *   @brief Perform particles collisions with other particles using soft sphere collision model
 *
 *   @param displacement: total normal displacement
+*   @param column: particle i index
+*   @param row: particle j index
 *   @param particleCenter: particles centers to perform colision index i
 *   @param particleCenter: particles centers to perform colision index j
+*   @param step: current time step
 */
 __device__ 
 void gpuSoftSphereParticleCollision(
     dfloat displacement,
+    unsigned int column,
+    unsigned int row,
     ParticleCenter* pc_i,
-    ParticleCenter* pc_j
+    ParticleCenter* pc_j,
+    unsigned int step
 );
 
 /**
-*   @brief Perform collision displacement tracker
+*   @brief Perform collision displacement tracker between particle and wall
 *   
 *   @param n: wall normal vector  
 *   @param pc_i: particles centers to perform colision
 *   @param step: current time step
 */
 __device__
-dfloat3 gpuTangentialDisplacementTracker(
+int gpuTangentialDisplacementTrackerWall(
     dfloat3 n,
     ParticleCenter* pc_i,
     unsigned int step
 );
+
+
+/**
+*   @brief Perform collision displacement tracker between particles
+*   
+*   @param column: particle i index
+*   @param row: particle j index
+*   @param pc_i: particles centers to perform colision
+*   @param pc_j: particles centers to perform colision
+*   @param step: current time step
+*/
+__device__
+int gpuTangentialDisplacementTrackerParticle(
+    unsigned int column,
+    unsigned int row,
+    ParticleCenter* pc_i,
+    ParticleCenter* pc_j,
+    unsigned int step
+);
+
+
 
 
 #if defined LUBRICATION_FORCE
@@ -120,7 +147,7 @@ void gpuLubricationParticle(
 */
 __device__ 
 void gpuHardSphereWallCollision(
-    dfloat column,
+    unsigned int column,
     dfloat3 penetration,
     dfloat3 n,
     ParticleCenter* pc_i,
@@ -138,8 +165,8 @@ void gpuHardSphereWallCollision(
 */
 __device__ 
 void gpuHarSpheredParticleCollision(
-    dfloat column,
-    dfloat row,
+    unsigned int column,
+    unsigned int row,
     ParticleCenter* pc_i,
     ParticleCenter* pc_j,
     ParticleNodeSoA particlesNodes

--- a/src/CUDA/IBM/collision/ibmCollision.h
+++ b/src/CUDA/IBM/collision/ibmCollision.h
@@ -62,6 +62,20 @@ void gpuSoftSphereParticleCollision(
     ParticleCenter* pc_j
 );
 
+/**
+*   @brief Perform collision displacement tracker
+*   
+*   @param n: wall normal vector  
+*   @param pc_i: particles centers to perform colision
+*   @param step: current time step
+*/
+__device__
+dfloat3 gpuTangentialDisplacementTracker(
+    dfloat3 n,
+    ParticleCenter* pc_i,
+    unsigned int step
+);
+
 
 #if defined LUBRICATION_FORCE
 /**

--- a/src/CUDA/IBM/ibm.cu
+++ b/src/CUDA/IBM/ibm.cu
@@ -391,12 +391,15 @@ void gpuUpdateParticleCenterVelocityAndRotation(
     const dfloat inv_volume = 1 / pc->volume;
 
     // Update particle center velocity using its surface forces and the body forces
-    pc->vel.x = pc->vel_old.x + (( (pc->f_old.x * (1.0 - IBM_MOVEMENT_DISCRETIZATION ) + pc->f.x * IBM_MOVEMENT_DISCRETIZATION) + pc->dP_internal.x) * inv_volume 
-        + (pc->density - FLUID_DENSITY) * GX) / (pc->density);
-    pc->vel.y = pc->vel_old.y + (( (pc->f_old.y * (1.0 - IBM_MOVEMENT_DISCRETIZATION )  + pc->f.y * IBM_MOVEMENT_DISCRETIZATION) + pc->dP_internal.y) * inv_volume 
-        + (pc->density - FLUID_DENSITY) * GY) / (pc->density);
-    pc->vel.z = pc->vel_old.z + (( (pc->f_old.z * (1.0 - IBM_MOVEMENT_DISCRETIZATION )  + pc->f.z * IBM_MOVEMENT_DISCRETIZATION) + pc->dP_internal.z) * inv_volume 
-        + (pc->density - FLUID_DENSITY) * GZ) / (pc->density);
+    pc->vel.x = pc->vel_old.x + (( (pc->f_old.x * (1.0 - IBM_MOVEMENT_DISCRETIZATION ) 
+                + pc->f.x * IBM_MOVEMENT_DISCRETIZATION) + pc->dP_internal.x) * inv_volume 
+                + (pc->density - FLUID_DENSITY) * GX) / (pc->density);
+    pc->vel.y = pc->vel_old.y + (( (pc->f_old.y * (1.0 - IBM_MOVEMENT_DISCRETIZATION )  
+                + pc->f.y * IBM_MOVEMENT_DISCRETIZATION) + pc->dP_internal.y) * inv_volume 
+                + (pc->density - FLUID_DENSITY) * GY) / (pc->density);
+    pc->vel.z = pc->vel_old.z + (( (pc->f_old.z * (1.0 - IBM_MOVEMENT_DISCRETIZATION )  
+                + pc->f.z * IBM_MOVEMENT_DISCRETIZATION) + pc->dP_internal.z) * inv_volume 
+                + (pc->density - FLUID_DENSITY) * GZ) / (pc->density);
 
     // Auxiliary variables for angular velocity update
     dfloat error = 1;

--- a/src/CUDA/IBM/ibm.cu
+++ b/src/CUDA/IBM/ibm.cu
@@ -49,7 +49,7 @@ void immersedBoundaryMethod(
     checkCudaErrors(cudaStreamSynchronize(streamIBM[0]));
     // Calculate collision force between particles
 
-    gpuParticlesCollision<<<GRID_PCOLLISION_IBM, THREADS_PCOLLISION_IBM, 0, streamIBM[0]>>>(particles.nodesSoA,particles.pCenterArray);
+    gpuParticlesCollision<<<GRID_PCOLLISION_IBM, THREADS_PCOLLISION_IBM, 0, streamIBM[0]>>>(particles.nodesSoA,particles.pCenterArray,step);
     checkCudaErrors(cudaStreamSynchronize(streamIBM[0]));   
 
     // First update particle velocity using body center force and constant forces

--- a/src/CUDA/IBM/ibmParticlesCreation.cpp
+++ b/src/CUDA/IBM/ibmParticlesCreation.cpp
@@ -32,14 +32,14 @@ void createParticles(Particle particles[NUM_PARTICLES])
     
     // Falling sphere
     dfloat3 center,vel, w;
-    dfloat angle = 6.0;
+    dfloat angle = 0.0;
     vel.x = 0.0;
     vel.y =  0.01*sin(angle*M_PI/180.0);
     vel.z = -0.01*cos(angle*M_PI/180.0);
 
     center.x = 100;
     center.y = 100;
-    center.z = 10.0 - 100.0*vel.z;
+    center.z = 30.0; //10.005 - 100.0*vel.z;
 
     w.x = 0.0;
     w.y = 0.0;
@@ -57,7 +57,7 @@ void createParticles(Particle particles[NUM_PARTICLES])
         dfloat3((NX)/2.0, (NY)/2.0, (NZ)/4.0), 
         MESH_COULOMB, false);
     */
-    /*
+    /*  
     // Sphere in couette flow (Neutrally buoyant particle in a shear flow)
     particles[0] = makeSpherePolar(
         PARTICLE_DIAMETER, 

--- a/src/CUDA/IBM/ibmParticlesCreation.cpp
+++ b/src/CUDA/IBM/ibmParticlesCreation.cpp
@@ -32,17 +32,21 @@ void createParticles(Particle particles[NUM_PARTICLES])
     
     // Falling sphere
      dfloat3 center,vel, w;
-    center.x = 100;
-    center.y = 100;
-    center.z = 14.995;
+
     vel.x = 0.0;
     vel.y = 0.0;
-    vel.z = -0.1;
+    vel.z = -0.01;
+
+    center.x = 100;
+    center.y = 100;
+    center.z = 10.0 -50 *vel.z ; 
     w.x = 0.0;
     w.y = 0.0;
     w.z = 0.0;
     for(int i = 0; i <NUM_PARTICLES ; i++){
         particles[i] = makeSpherePolar(PARTICLE_DIAMETER, center , MESH_COULOMB, true,PARTICLE_DENSITY,vel,w);
+        printf("\n bbbb %d",particles[i].pCenter.tCT[0].collisionIndex);fflush(stdout); 
+        printf("\n cccc %d",particles[i].pCenter.tCT[17].collisionIndex);fflush(stdout); 
     }
     /*
     // Fixed sphere

--- a/src/CUDA/IBM/ibmParticlesCreation.cpp
+++ b/src/CUDA/IBM/ibmParticlesCreation.cpp
@@ -32,14 +32,14 @@ void createParticles(Particle particles[NUM_PARTICLES])
     
     // Falling sphere
     dfloat3 center,vel, w;
-    dfloat angle = 0.0;
+    dfloat angle = 11.0;
     vel.x = 0.0;
     vel.y =  0.01*sin(angle*M_PI/180.0);
     vel.z = -0.01*cos(angle*M_PI/180.0);
 
     center.x = 100;
     center.y = 100;
-    center.z = 30.0; //10.005 - 100.0*vel.z;
+    center.z = 10.005 - 100.0*vel.z;
 
     w.x = 0.0;
     w.y = 0.0;
@@ -47,8 +47,6 @@ void createParticles(Particle particles[NUM_PARTICLES])
 
     for(int i = 0; i <NUM_PARTICLES ; i++){
         particles[i] = makeSpherePolar(PARTICLE_DIAMETER, center , MESH_COULOMB, true,PARTICLE_DENSITY,vel,w);
-        printf("\n bbbb %d",particles[i].pCenter.tCT[0].collisionIndex);fflush(stdout); 
-        printf("\n cccc %d",particles[i].pCenter.tCT[17].collisionIndex);fflush(stdout); 
     }
     /*
     // Fixed sphere

--- a/src/CUDA/IBM/ibmParticlesCreation.cpp
+++ b/src/CUDA/IBM/ibmParticlesCreation.cpp
@@ -31,18 +31,20 @@ void createParticles(Particle particles[NUM_PARTICLES])
 
     
     // Falling sphere
-     dfloat3 center,vel, w;
-
+    dfloat3 center,vel, w;
+    dfloat angle = 6.0;
     vel.x = 0.0;
-    vel.y = 0.0;
-    vel.z = -0.01;
+    vel.y =  0.01*sin(angle*M_PI/180.0);
+    vel.z = -0.01*cos(angle*M_PI/180.0);
 
     center.x = 100;
     center.y = 100;
-    center.z = 10.0 -50 *vel.z ; 
+    center.z = 10.0 - 100.0*vel.z;
+
     w.x = 0.0;
     w.y = 0.0;
     w.z = 0.0;
+
     for(int i = 0; i <NUM_PARTICLES ; i++){
         particles[i] = makeSpherePolar(PARTICLE_DIAMETER, center , MESH_COULOMB, true,PARTICLE_DENSITY,vel,w);
         printf("\n bbbb %d",particles[i].pCenter.tCT[0].collisionIndex);fflush(stdout); 

--- a/src/CUDA/IBM/ibmVar.h
+++ b/src/CUDA/IBM/ibmVar.h
@@ -37,6 +37,7 @@
 #define SOFT_SPHERE //https://doi.org/10.1201/b11103  chapter 5
 //#define EXTERNAL_DUCT_BC //necessary if using annularDuctInterpBounceBack or annularDuctInterpBounceBack
 //#define INTERNAL_DUCT_BC //necessary if using annularDuctInterpBounceBack
+#define trackerCollisionSize 18
 /* ------------------------------------------------------------------------- */
 
 
@@ -95,12 +96,12 @@ constexpr dfloat GZ = 0.0; //-1.179430e-03/SCALE/SCALE/SCALE;
 
 
 constexpr dfloat FRICTION_COEF = 0.001; // friction coeficient
-constexpr dfloat REST_COEF = 1.0; // restitution coeficient   
+constexpr dfloat REST_COEF = 0.5; // restitution coeficient   
 #define REST_COEF_CORRECTION
 
 
 //material properties
-constexpr dfloat YOUNG_MODULUS = 1.0;
+constexpr dfloat YOUNG_MODULUS = 100.0;
 constexpr dfloat POISSON_RATIO = 0.33;
 constexpr dfloat SHEAR_MODULUS = YOUNG_MODULUS / (2.0+2.0*POISSON_RATIO);
 

--- a/src/CUDA/IBM/ibmVar.h
+++ b/src/CUDA/IBM/ibmVar.h
@@ -68,6 +68,11 @@
 // Leave as 1 if you're not interested in this optimization
 #define IBM_EULER_UPDATE_INTERVAL (10)
 
+
+//Define the discrization coefiecient for the particle movement: 1 = only current time step
+// 0.5 =  half current and half previous,  0 = only previous time step information
+#define IBM_MOVEMENT_DISCRETIZATION (1.0)  //TODO: its not the correct name, but for now i cant recall it.
+
 /* ------------------------------------------------------------------------- */
 
 /* ------------------------- TIME AND SAVE DEFINES ------------------------- */
@@ -96,12 +101,12 @@ constexpr dfloat GZ = 0.0; //-1.179430e-03/SCALE/SCALE/SCALE;
 
 
 constexpr dfloat FRICTION_COEF = 0.0923; // friction coeficient
-constexpr dfloat REST_COEF = 0.98; // restitution coeficient   
-#define REST_COEF_CORRECTION
+constexpr dfloat REST_COEF = 1.0; // restitution coeficient   
+//#define REST_COEF_CORRECTION
 
 
 //material properties
-constexpr dfloat YOUNG_MODULUS = 2366.0;
+constexpr dfloat YOUNG_MODULUS = 10.0;
 constexpr dfloat POISSON_RATIO = 0.24;
 constexpr dfloat SHEAR_MODULUS = YOUNG_MODULUS / (2.0+2.0*POISSON_RATIO);
 
@@ -119,12 +124,7 @@ constexpr dfloat FRICTION_COEF_CORRECTED = 1/((16.21*REST_COEF+15.58*REST_COEF*R
 #endif 
 
 
-constexpr dfloat ZETA = 1.0; // Distance threshold
-constexpr dfloat STIFF_WALL = 1.0;  // Stiffness parameter wall
-constexpr dfloat STIFF_SOFT = 1.0;  // Soft stiffness parameter particle
-constexpr dfloat STIFF_HARD = 0.1;  // Hard stiffness parameter particle
-
-#define LUBRICATION_FORCE
+//#define LUBRICATION_FORCE
 #if defined LUBRICATION_FORCE
     constexpr dfloat LUBRICATION_DISTANCE = 2;
 #endif

--- a/src/CUDA/IBM/ibmVar.h
+++ b/src/CUDA/IBM/ibmVar.h
@@ -81,7 +81,7 @@
 /* ------------------------------------------------------------------------- */
 
 /* ------------------------- FORCES AND DENSITIES --------------------------- */
-constexpr dfloat PARTICLE_DENSITY = 1.154639;
+constexpr dfloat PARTICLE_DENSITY = 3.97;
 constexpr dfloat FLUID_DENSITY = 1;
 
 // Gravity accelaration on particle (Lattice units)
@@ -95,14 +95,14 @@ constexpr dfloat GZ = 0.0; //-1.179430e-03/SCALE/SCALE/SCALE;
 #if defined SOFT_SPHERE
 
 
-constexpr dfloat FRICTION_COEF = 0.001; // friction coeficient
-constexpr dfloat REST_COEF = 0.5; // restitution coeficient   
+constexpr dfloat FRICTION_COEF = 0.0923; // friction coeficient
+constexpr dfloat REST_COEF = 0.98; // restitution coeficient   
 #define REST_COEF_CORRECTION
 
 
 //material properties
-constexpr dfloat YOUNG_MODULUS = 100.0;
-constexpr dfloat POISSON_RATIO = 0.33;
+constexpr dfloat YOUNG_MODULUS = 2366.0;
+constexpr dfloat POISSON_RATIO = 0.24;
 constexpr dfloat SHEAR_MODULUS = YOUNG_MODULUS / (2.0+2.0*POISSON_RATIO);
 
 

--- a/src/CUDA/IBM/ibmVar.h
+++ b/src/CUDA/IBM/ibmVar.h
@@ -101,20 +101,20 @@ constexpr dfloat GZ = 0.0; //-1.179430e-03/SCALE/SCALE/SCALE;
 
 
 constexpr dfloat FRICTION_COEF = 0.0923; // friction coeficient
-constexpr dfloat REST_COEF = 1.0; // restitution coeficient   
+constexpr dfloat REST_COEF = 0.98; // restitution coeficient   
 //#define REST_COEF_CORRECTION
 
 
 //material properties
-constexpr dfloat YOUNG_MODULUS = 10.0;
+constexpr dfloat YOUNG_MODULUS = 385.0;
 constexpr dfloat POISSON_RATIO = 0.24;
 constexpr dfloat SHEAR_MODULUS = YOUNG_MODULUS / (2.0+2.0*POISSON_RATIO);
 
 
 //Hertzian contact theory -  Johnson 1985
-constexpr dfloat STIFFNESS_NORMAL_CONST = (2.0/3.0) * (YOUNG_MODULUS / (1-POISSON_RATIO*POISSON_RATIO)); 
+constexpr dfloat STIFFNESS_NORMAL_CONST = (2.0/3.0) * (YOUNG_MODULUS / (1-POISSON_RATIO*POISSON_RATIO)); // its 2 instead of 4, because same shear modulus
 //Mindlin theory 1949
-constexpr dfloat STIFFNESS_TANGENTIAL_CONST =  4.0 * (SHEAR_MODULUS / (1 - POISSON_RATIO*POISSON_RATIO)); 
+constexpr dfloat STIFFNESS_TANGENTIAL_CONST =  4.0 * (SHEAR_MODULUS / (1 - POISSON_RATIO*POISSON_RATIO)); // its 4 instead of 8, because same shear modulus
 // Tsuji 1979
 //constexpr dfloat DAMPING_NORMAL_CONST =       - 2.0 * log(REST_COEF)  / (sqrt(M_PI*M_PI + log(REST_COEF)));
 //constexpr dfloat DAMPING_TANGENTIAL_CONST =   - 2.0 * log(REST_COEF)  / (sqrt(M_PI*M_PI + log(REST_COEF))); 

--- a/src/CUDA/IBM/structs/particleCenter.h
+++ b/src/CUDA/IBM/structs/particleCenter.h
@@ -13,6 +13,36 @@
 #include "../../structs/globalStructs.h"
 #include "../ibmVar.h"
 
+typedef struct tangentialCollisionTracker {
+    
+    
+    /*
+    -4 : Special, i.e round boundary;
+    -7 : Front
+    -1 : Back
+    -6 : North
+    -2 : South
+    -3 : West
+    -5 : East
+    0 >= : particle ID
+    */
+    int collisionIndex;
+    dfloat3 tang_length;
+    unsigned int lastCollisionStep;
+    
+
+    /* Constructor */
+    __host__ __device__
+    tangentialCollisionTracker()
+    {
+        collisionIndex = -8;
+        tang_length = dfloat3();
+        lastCollisionStep = 0;
+    }
+} TangentialCollisionTracker;
+
+
+
 /*
 *   Struct for the particle center properties
 */
@@ -36,6 +66,8 @@ typedef struct particleCenter {
     dfloat volume;      // Particle volume
     dfloat density;     // Particle density
     bool movable;       // If the particle can move
+
+    tangentialCollisionTracker tCT[trackerCollisionSize];
 
     /* Constructor */
     particleCenter()

--- a/src/CUDA/var.h
+++ b/src/CUDA/var.h
@@ -44,7 +44,7 @@
 
 /* ------------------------- TIME CONSTANTS DEFINES ------------------------ */
 constexpr unsigned int SCALE = 1;
-constexpr int N_STEPS = 2200;          // maximum number of time steps
+constexpr int N_STEPS = 500;          // maximum number of time steps
 #define MACR_SAVE (0)                  // saves macroscopics every MACR_SAVE steps
 #define DATA_REPORT (false)                // report every DATA_REPORT steps
  

--- a/src/CUDA/var.h
+++ b/src/CUDA/var.h
@@ -44,7 +44,7 @@
 
 /* ------------------------- TIME CONSTANTS DEFINES ------------------------ */
 constexpr unsigned int SCALE = 1;
-constexpr int N_STEPS = 300;          // maximum number of time steps
+constexpr int N_STEPS = 2200;          // maximum number of time steps
 #define MACR_SAVE (0)                  // saves macroscopics every MACR_SAVE steps
 #define DATA_REPORT (false)                // report every DATA_REPORT steps
  

--- a/src/CUDA/var.h
+++ b/src/CUDA/var.h
@@ -35,7 +35,7 @@
 #endif
 
 /* ----------------------------- OUTPUT DEFINES ---------------------------- */
-#define ID_SIM "000"            // prefix for simulation's files
+#define ID_SIM "001"            // prefix for simulation's files
 #define PATH_FILES "TEST"  // path to save simulation's files
                     // the final path is PATH_FILES/ID_SIM
                     // DO NOT ADD "/" AT THE END OF PATH_FILES

--- a/src/CUDA/var.h
+++ b/src/CUDA/var.h
@@ -44,7 +44,7 @@
 
 /* ------------------------- TIME CONSTANTS DEFINES ------------------------ */
 constexpr unsigned int SCALE = 1;
-constexpr int N_STEPS = 100;          // maximum number of time steps
+constexpr int N_STEPS = 300;          // maximum number of time steps
 #define MACR_SAVE (0)                  // saves macroscopics every MACR_SAVE steps
 #define DATA_REPORT (false)                // report every DATA_REPORT steps
  


### PR DESCRIPTION
- The tangential force during contact now properly accounts for the total displacement.
- A new function was added to keep track between particles and walls in order to perform the above. (These functions (`gpuTangentialDisplacementTrackerWall `and `gpuTangentialDisplacementTrackerParticle `) may need a refactor in the future) 
- A new struct was added to kept track of it, it is used inside `particleCenter`, the definition `trackerCollisionSize `defines how many collisions it can track simultaneously (currently is set 14 (hexagonal packing) + 3 walls +1 spare = 18) 
- A new variable was added (`IBM_MOVEMENT_DISCRETIZATION `) for the IBM, it changes the weights in the movement equations between the previous time step and the current one to determine in the next time-step
- Some fixes to the soft-sphere model which are missing between the particle-wall and particle-particle collisions

