### PR TITLE
Fix atomic add double precision

### DIFF
--- a/src/CUDA/IBM/ibmGlobalFunctions.h
+++ b/src/CUDA/IBM/ibmGlobalFunctions.h
@@ -28,7 +28,7 @@
 *               atomicDoubleAdd(a, addedValue);
 *           }
 */
-/*
+
 __device__ double atomicAdd(double* address, double val)
 {
     unsigned long long int* address_as_ull =
@@ -46,7 +46,7 @@ __device__ double atomicAdd(double* address, double val)
 
     return __longlong_as_double(old);
 }
-*/
+
 #endif
 
 /*

--- a/src/CUDA/IBM/ibmGlobalFunctions.h
+++ b/src/CUDA/IBM/ibmGlobalFunctions.h
@@ -16,7 +16,7 @@
 
 // Only compile for compute capability lower than 6.0, since for 6.0 or higher
 // this functionality already exists
-#if __CUDA_ARCH__ < 600
+  #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
 /*
 *   @brief Double atomic add for Cuda capabailities less than 6.0
 *   @param address: memory address where will be added the value
@@ -28,24 +28,24 @@
 *               atomicDoubleAdd(a, addedValue);
 *           }
 */
-
-__device__ double atomicAdd(double* address, double val)
+#else
+static __inline__ __device__ double atomicAdd(double* address, double val)
 {
     unsigned long long int* address_as_ull =
                               (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;
-
+    if (val==0.0)
+      return __longlong_as_double(old);
     do {
-        assumed = old;
-        old = atomicCAS(address_as_ull, assumed,
+      assumed = old;
+        old = atomicCAS(address_as_ull, assumed, 
                         __double_as_longlong(val +
                                __longlong_as_double(assumed)));
 
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
     } while (assumed != old);
-
     return __longlong_as_double(old);
-}
+  }
 
 #endif
 


### PR DESCRIPTION
When compiling with double precision for cuda<6.0, was not compiling.
This should fix the compiling error, and enable the it back.